### PR TITLE
Fixes error with missing datastore object

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,3 +6,8 @@ data "vsphere_compute_cluster" "homelab" {
   name = "homelab"
   datacenter_id = data.vsphere_datacenter.garage.id
 }
+
+data "vsphere_datastore" "vsan" {
+  name          = "vsanDatastore"
+  datacenter_id = data.vsphere_datacenter.garage.id
+}


### PR DESCRIPTION
TL;DR
-----

Adds missing Terraform object required for content libraries

Details
-------

The merge that added content libraries was missing a change that
added a data source for the vSAN datastore. This commit adds the
file so that things will work.