### PR TITLE
Creates storage policies for Kubernetes

### DIFF
--- a/policy.tf
+++ b/policy.tf
@@ -1,0 +1,42 @@
+resource "vsphere_tag_category" "storage" {
+  name        = "Kubernetes Storage"
+  cardinality = "SINGLE"
+
+  associable_types = [
+    "Datastore",
+  ]
+}
+
+resource "vsphere_tag" "vsan" {
+  name        = "vsan"
+  category_id = vsphere_tag_category.storage.id
+}
+
+resource "vsphere_vm_storage_policy" "vsan" {
+  name        = "vsan"
+  description = "vSAN storage for Kubernetes clusters"
+
+  tag_rules {
+    tag_category                 = vsphere_tag_category.storage.name
+    tags                         = [ vsphere_tag.vsan.name ]
+    include_datastores_with_tags = true
+  }
+
+}
+
+resource "vsphere_tag" "usb" {
+  name        = "usb"
+  category_id = vsphere_tag_category.storage.id
+}
+
+resource "vsphere_vm_storage_policy" "usb" {
+  name        = "usb"
+  description = "USB attached storage for Kubernetes clusters"
+
+  tag_rules {
+    tag_category                 = vsphere_tag_category.storage.name
+    tags                         = [ vsphere_tag.usb.name ]
+    include_datastores_with_tags = true
+  }
+
+}


### PR DESCRIPTION
TL;DR
-----

Adds policies to enable storage access from Kubernetes

Details
-------

Creates two storage policies for adding storage to Kubernetes
clusters. One named `vsan` for vSAN storage in the lab, and the
other one for USB attached storage (named `usb`). Both policies
use tagging to identify which storage is available. The tags
are in a category called "Kubernetes Storage" to clarify their
intent.  This code creates the category and tags.