### PR TITLE
Switches the default lab subdomain 

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -2,7 +2,7 @@ export PROJECT_DIR=${PWD}
 PATH=${PROJECT_DIR}/bin:${PATH}
 SECRETS_DIR=${PROJECT_DIR}/secrets
 
-export TF_VAR_domain=crdant.net
+export TF_VAR_domain=shortrib.net
 export TF_VAR_email=cdantonio@vmware.com
 export TF_VAR_project_root=${PROJECT_DIR}
 export TF_VAR_environment=lab


### PR DESCRIPTION
TL;DR
-----

Supports lab subdomain of `lab.shortrib.net` instead of
`lab.crdant.net`

Details
-------

I decided to rename the subdomain for my homelab from the fairly
straightforward `lab.crdant.net` to a more whimsical option that
matches my new public-facing demo domain of `shortrib.io`. Thus
`lab.shortrib.net` was born. This change adapts this code to
support installing a supervisor cluster in a lab with that
domain.