### PR TITLE
Renames the load balancer port group

### DIFF
--- a/network.tf
+++ b/network.tf
@@ -46,7 +46,7 @@ resource "vsphere_vnic" "workload" {
 }
 
 resource "vsphere_distributed_port_group" "load_balancer" {
-  name                            = "load-balancer-pg"
+  name                            = "frontend-pg"
   distributed_virtual_switch_uuid = data.vsphere_distributed_virtual_switch.homelab.id
 
   vlan_id = 104


### PR DESCRIPTION
TL;DR
-----

Uses "frontend" to describe the load balancer port group

Details
-------

Updates the name for the load balancer port group to the slightly
less unwieldy `frontend-pg`.